### PR TITLE
src: explicitly include <cstdlib>

### DIFF
--- a/include/nbytes.h
+++ b/include/nbytes.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 


### PR DESCRIPTION
While upgrading Chrome from trunk, nbytes is now failing to build with the following error:
```
In file included from ../../deps/nbytes/src/nbytes.cpp:1:
../../deps/nbytes/include/nbytes.h:604:22: error: use of undeclared identifier 'abort'
  604 |     if (idx < start) abort();
      |                      ^~~~~
../../deps/nbytes/include/nbytes.h:609:22: error: use of undeclared identifier 'abort'
  609 |     if (idx < start) abort();
```

It seems as though a transitive dependency that previously imported <cstdlib> may have been removed. This PR adds <cstdlib> into the header includes, so any future breaks don't happen.