### PR TITLE
feat(cmake): add option for disabling tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,18 +12,26 @@ option(NBYTES_DEVELOPMENT_CHECKS "Enable development checks" OFF)
 
 include(GNUInstallDirs)
 include(FetchContent)
+include(CTest)
 
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+option(NBYTES_ENABLE_TESTING "Enable testing" ${BUILD_TESTING})
+
 
 add_subdirectory(src)
-enable_testing()
-add_subdirectory(tests)
+
+if (NBYTES_ENABLE_TESTING)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+    URL_HASH SHA256=edd885a1ab32b6999515a880f669efadb80b3f880215f315985fa3f6eca7c4d3
+    FIND_PACKAGE_ARGS NAMES GTest
+  )
+  # For Windows: Prevent overriding the parent project's compiler/linker settings
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  add_subdirectory(tests)
+endif()
 
 install(
   FILES include/nbytes.h


### PR DESCRIPTION
This pull request updates the project's `CMakeLists.txt` to improve how testing is enabled and managed. The main changes introduce a new option for controlling test builds, conditionally include test dependencies and directories, and improve reproducibility by specifying a hash for the `googletest` dependency.

Testing configuration improvements:

* Added a new CMake option `NBYTES_ENABLE_TESTING` to control whether testing is enabled, defaulting to the value of `BUILD_TESTING` (`option(NBYTES_ENABLE_TESTING "Enable testing" ${BUILD_TESTING})`).
* Now only adds the `tests` subdirectory and fetches `googletest` if testing is enabled, making test dependencies optional for non-testing builds.
* Added a SHA256 hash for the `googletest` dependency to ensure consistent and secure downloads.

General build system improvements:

* Moved the addition of the `src` subdirectory to occur before the conditional test logic, ensuring core sources are always included.

PS: Only the pr description was generated via ai.
PPS: Tests are on by default and can be controlled via BUILD_TESTING or NBYTES_ENABLE_TESTING. 